### PR TITLE
Replace Carriagereturn newline escapes

### DIFF
--- a/nick_bot.java
+++ b/nick_bot.java
@@ -390,7 +390,7 @@ public class nick_bot {
       if (line.contains("\"definition\":")) {
         temp = line.substring(line.indexOf("\"definition\":") + 14, line.indexOf(",\"permalink\"") - 1);
         temp.replaceAll("\\\"", "\"");
-        temp.replaceAll("[^\\{IsLetter}]+", " ");
+        temp.replaceAll("\\r\\n", "\r\n");
         if (temp.length() > 150) {
           temp = temp.substring(0, 150) + "...";
         }

--- a/nick_bot.java
+++ b/nick_bot.java
@@ -390,7 +390,8 @@ public class nick_bot {
       if (line.contains("\"definition\":")) {
         temp = line.substring(line.indexOf("\"definition\":") + 14, line.indexOf(",\"permalink\"") - 1);
         temp.replaceAll("\\\"", "\"");
-        temp.replaceAll("\\r\\n", "\r\n");
+        temp.replaceAll("\\r", "\r");
+        temp.replaceAll("\\n", "\n");
         if (temp.length() > 150) {
           temp = temp.substring(0, 150) + "...";
         }


### PR DESCRIPTION
I haven't tested it. Sometimes nickbot will return stuff with "\n" and "\r" escaped. This SHOULD fix it, but test it first.

example command you can do: `urban arse
